### PR TITLE
chore: sponsor button via .github/FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+# Sponsor button (repo sidebar).
+#   github: the GitHub Sponsors profile of the blaizio organization.
+#   open_collective: enable once the Blaizio collective exists (slug = the part after opencollective.com/).
+github: blaizio
+# open_collective: blaizio-ui


### PR DESCRIPTION
Adds the repository Sponsor button pointing at the blaizio organization's GitHub Sponsors profile. The Open Collective entry stays commented until the collective exists.