### PR TITLE
docs: accordion demos ask about Blaizio, not about themselves

### DIFF
--- a/docs/Blaizio.Docs/Examples/Accordion/AccordionDefaultExample.razor
+++ b/docs/Blaizio.Docs/Examples/Accordion/AccordionDefaultExample.razor
@@ -1,14 +1,14 @@
 <BzAccordion DefaultValue="item-1" Collapsible Class="w-full max-w-md">
     <BzAccordionItem Value="item-1">
-        <BzAccordionTrigger>Is it accessible?</BzAccordionTrigger>
-        <BzAccordionContent>Yes. It follows the WAI-ARIA accordion pattern: a heading-wrapped button wired to its region.</BzAccordionContent>
+        <BzAccordionTrigger>Where does the code live?</BzAccordionTrigger>
+        <BzAccordionContent>In your project. The CLI copies each component in as source under your namespace, so this file is yours to edit.</BzAccordionContent>
     </BzAccordionItem>
     <BzAccordionItem Value="item-2">
-        <BzAccordionTrigger>Is it styled?</BzAccordionTrigger>
-        <BzAccordionContent>Yes. All eight Blaizio styles skin it - switch the style above to compare.</BzAccordionContent>
+        <BzAccordionTrigger>How is it styled?</BzAccordionTrigger>
+        <BzAccordionContent>Tailwind classes inlined per skin. All eight Blaizio styles skin it - switch the style above to compare.</BzAccordionContent>
     </BzAccordionItem>
     <BzAccordionItem Value="item-3">
-        <BzAccordionTrigger>Is it animated?</BzAccordionTrigger>
-        <BzAccordionContent>Yes. The open and close animate to the panel's measured height.</BzAccordionContent>
+        <BzAccordionTrigger>What does the trigger render?</BzAccordionTrigger>
+        <BzAccordionContent>A button inside a heading, wired to its panel with aria-expanded and aria-controls. The heading level is a parameter.</BzAccordionContent>
     </BzAccordionItem>
 </BzAccordion>

--- a/docs/Blaizio.Docs/Examples/Accordion/AccordionUsageExample.razor
+++ b/docs/Blaizio.Docs/Examples/Accordion/AccordionUsageExample.razor
@@ -1,10 +1,10 @@
 <BzAccordion DefaultValue="item-1" Collapsible>
     <BzAccordionItem Value="item-1">
-        <BzAccordionTrigger>Is it accessible?</BzAccordionTrigger>
-        <BzAccordionContent>Yes. It follows the WAI-ARIA accordion pattern.</BzAccordionContent>
+        <BzAccordionTrigger>Where does the code live?</BzAccordionTrigger>
+        <BzAccordionContent>In your project, as source under your namespace.</BzAccordionContent>
     </BzAccordionItem>
     <BzAccordionItem Value="item-2">
-        <BzAccordionTrigger>Is it styled?</BzAccordionTrigger>
-        <BzAccordionContent>Yes. All eight Blaizio styles skin it.</BzAccordionContent>
+        <BzAccordionTrigger>How is it styled?</BzAccordionTrigger>
+        <BzAccordionContent>Tailwind classes inlined per skin; all eight Blaizio styles skin it.</BzAccordionContent>
     </BzAccordionItem>
 </BzAccordion>

--- a/docs/Blaizio.Docs/Pages/Themes/PreviewControls.razor
+++ b/docs/Blaizio.Docs/Pages/Themes/PreviewControls.razor
@@ -7,8 +7,8 @@
     <BzCardContent>
         <BzAccordion DefaultValue="faq-1" Collapsible Class="w-full">
             <BzAccordionItem Value="faq-1">
-                <BzAccordionTrigger>Is it accessible?</BzAccordionTrigger>
-                <BzAccordionContent>Yes - WAI-ARIA patterns throughout, keyboard first.</BzAccordionContent>
+                <BzAccordionTrigger>How do updates work?</BzAccordionTrigger>
+                <BzAccordionContent>blaizio update re-pulls the components and keeps the files you edited.</BzAccordionContent>
             </BzAccordionItem>
             <BzAccordionItem Value="faq-2">
                 <BzAccordionTrigger>Can I change styles later?</BzAccordionTrigger>

--- a/docs/Blaizio.Docs/Pages/Themes/PreviewOverlays.razor
+++ b/docs/Blaizio.Docs/Pages/Themes/PreviewOverlays.razor
@@ -14,8 +14,8 @@
             <BzTabsContent Value="faq" Class="pt-3">
                 <BzAccordion>
                     <BzAccordionItem Value="a">
-                        <BzAccordionTrigger>Is it accessible?</BzAccordionTrigger>
-                        <BzAccordionContent>Yes. It follows the WAI-ARIA design pattern.</BzAccordionContent>
+                        <BzAccordionTrigger>Where does the code live?</BzAccordionTrigger>
+                        <BzAccordionContent>In your project, as source under your namespace.</BzAccordionContent>
                     </BzAccordionItem>
                     <BzAccordionItem Value="b">
                         <BzAccordionTrigger>Is it themeable?</BzAccordionTrigger>


### PR DESCRIPTION
The accordion demos and the two Themes preview accordions used the generic "Is it accessible? / Is it styled? / Is it animated?" questions that several component libraries ship verbatim. They now ask about the things Blaizio does differently: where the code lives, how a skin styles a component, what the trigger renders, how updates merge.