### PR TITLE
fix(dialog): no first-open stutter - hide the surface until its portal hop lands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ lockstep under one version.
   instead of item names.
 
 ### Fixed
+- **Dialog, Sheet, Drawer, AlertDialog**: the first open no longer stutters. The surface rendered
+  at its declaration site, started its entry animation there, and moved to `<body>` one interop
+  roundtrip later, which restarts CSS animations - so the entry played twice, visibly on a cold
+  Blazor Server circuit. The window and overlay now carry `data-bz-portal` and `blaizio.css`
+  keeps them invisible until they have arrived at body, so the one entry animation that shows is
+  the one that starts there. Inline surfaces are untouched. (Blaizio.Base + the `blaizio.css`
+  contract sheet.)
 - **Table**: the horizontal scroll container now ships `scrollbar-thin` like every other Blaizio
   scroll box, so a project that opted into the thin scrollbar gets it on a wide table too. Cells
   still keep `whitespace-nowrap` by design; pass `whitespace-normal` through `CellClass` (or a

--- a/src/Blaizio.Base/Components/Dialog/BaseDialogContent.razor
+++ b/src/Blaizio.Base/Components/Dialog/BaseDialogContent.razor
@@ -100,6 +100,10 @@
             // A portaled surface leaves any subtree direction provider's DOM ancestry, so the
             // cascaded direction is stamped on the element itself (inline keeps inheritance).
             .Set("dir", Inline ? DirAttribute : PortalDirAttribute)
+            // Marks a surface that is on its way to <body>: blaizio.css keeps it invisible while it
+            // still sits at its declaration site, so the entry animation the user sees is the one
+            // that starts after the move (moving a node restarts its CSS animations).
+            .Data("bz-portal", Inline ? null : "")
             .On("onkeydown", EventCallback.Factory.Create<KeyboardEventArgs>(this, OnKeyDownAsync));
 
         // Reference a title/description only when one is actually rendered - a dangling aria-labelledby/

--- a/src/Blaizio.Base/Components/Dialog/BaseDialogOverlay.razor
+++ b/src/Blaizio.Base/Components/Dialog/BaseDialogOverlay.razor
@@ -66,6 +66,8 @@
             // A portaled overlay leaves any subtree direction provider's DOM ancestry, so the
             // cascaded direction is stamped on the element itself (inline keeps inheritance).
             .Set("dir", Inline ? DirAttribute : PortalDirAttribute)
+            // See BaseDialogContent: invisible until the portal hop lands, so the fade-in plays once.
+            .Data("bz-portal", Inline ? null : "")
             .Set("aria-hidden", "true");
         if (DismissOnOutsideClick) props.On("onpointerdown", EventCallback.Factory.Create(this, DismissAsync));
         return props.Merge(Attributes, Class, Style);

--- a/src/Blaizio.Ui/Styles/blaizio.css
+++ b/src/Blaizio.Ui/Styles/blaizio.css
@@ -153,6 +153,20 @@
   --tw-animation-fill-mode: forwards;
 }
 
+/* MARK: Portal hop
+   A dialog, sheet or drawer surface (window and overlay) renders at its declaration site first and
+   moves to <body> one interop roundtrip later (ts/portal.ts). Moving a node restarts its CSS
+   animations, so the entry would play twice: a few frames in place, then again from zero at body -
+   a visible first-open stutter, worst on a cold Blazor Server circuit where the hop lands two
+   roundtrips after the render. Keep the surface invisible until it has arrived: nothing paints in
+   place, and the one entry animation that shows is the one that starts at body (or inside a
+   data-bz-portal-frame theme scope, which is also a direct body child). Base stamps data-bz-portal
+   on every portaled surface; Inline surfaces never carry it. Focus waits for this too - the focus
+   scope holds its autofocus while the container is visibility:hidden. */
+[data-bz-portal]:not(body > *):not([data-bz-portal-frame] > *) {
+  visibility: hidden;
+}
+
 /* MARK: Marquee
    Contract-owned: ts/marquee.ts measures elements marked data-bz-marquee and stamps
    data-truncated on the ones whose text overflows. The element rests as a normal ellipsis

--- a/tests/Blaizio.Base.Tests/DialogRenderTests.cs
+++ b/tests/Blaizio.Base.Tests/DialogRenderTests.cs
@@ -16,7 +16,7 @@ public class DialogRenderTests : BunitContext
 {
     public DialogRenderTests() => JSInterop.Mode = JSRuntimeMode.Loose;
 
-    private static RenderFragment Parts(bool description = true) => builder =>
+    private static RenderFragment Parts(bool description = true, bool inline = false) => builder =>
     {
         builder.OpenComponent<BaseDialogTrigger>(0);
         builder.AddComponentParameter(1, nameof(BaseDialogTrigger.ChildContent),
@@ -24,9 +24,11 @@ public class DialogRenderTests : BunitContext
         builder.CloseComponent();
 
         builder.OpenComponent<BaseDialogOverlay>(2);
+        builder.AddComponentParameter(5, nameof(BaseDialogOverlay.Inline), inline);
         builder.CloseComponent();
 
         builder.OpenComponent<BaseDialogContent>(3);
+        builder.AddComponentParameter(6, nameof(BaseDialogContent.Inline), inline);
         builder.AddComponentParameter(4, nameof(BaseDialogContent.ChildContent), (RenderFragment)(c =>
         {
             c.OpenComponent<BaseDialogTitle>(0);
@@ -49,6 +51,23 @@ public class DialogRenderTests : BunitContext
         }));
         builder.CloseComponent();
     };
+
+    [Fact]
+    public void Portaled_surfaces_carry_the_portal_marker_and_inline_ones_do_not()
+    {
+        // blaizio.css keeps a [data-bz-portal] surface invisible until portal.ts has moved it to
+        // <body>, so the entry animation plays once, there - the marker must be on both the window
+        // and the overlay, and absent when the surface stays in place.
+        var cut = Render<BaseDialog>(p => p.AddChildContent(Parts()));
+        cut.Find("button").Click();
+        Assert.Equal("", cut.Find("[role=dialog]").GetAttribute("data-bz-portal"));
+        Assert.Equal("", cut.Find("[aria-hidden=true]").GetAttribute("data-bz-portal"));
+
+        var inline = Render<BaseDialog>(p => p.AddChildContent(Parts(inline: true)));
+        inline.Find("button").Click();
+        Assert.Null(inline.Find("[role=dialog]").GetAttribute("data-bz-portal"));
+        Assert.Null(inline.Find("[aria-hidden=true]").GetAttribute("data-bz-portal"));
+    }
 
     [Fact]
     public void Closed_renders_only_the_trigger_with_collapsed_aria()


### PR DESCRIPTION
Reported on a consumer app (Blazor Server): the dialog flickers on its first open after page load, later opens are clean; the module warm-up did not remove it.

Cause: the surface renders at its declaration site, starts its entry animation there, and portal.ts moves it to `<body>` one interop roundtrip later. Moving a node restarts its CSS animations, so the entry plays twice. Measured on a scaffolded Server app: rendered in place at t=0, moved at t=12 ms carrying a new Animation object. A cold circuit stretches the gap to two roundtrips, so the first run paints before the restart.

Fix: Base stamps `data-bz-portal` on the window and overlay (not on Inline surfaces); `blaizio.css` keeps a marked surface `visibility: hidden` until it is a direct child of body (or of a `data-bz-portal-frame` scope). Nothing paints in place; the one entry animation that shows starts at body. Focus already waits for visibility in focusScope.ts and landed 8 ms after the hop in the same measurement. Close, scroll unlock and focus return verified unchanged.

- Base render test: marker on both surfaces, absent inline (432/432).
- Cli.Core 489/489, Cli 171/171 (blaizio.css is an embedded contract sheet).
- Ships with the next Blaizio.Base release; consumers get the css rule through the contract sheet.