### PR TITLE
fix(cli): showcase submit buttons pass ButtonType.Submit, not a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ lockstep under one version.
   instead of item names.
 
 ### Fixed
+- **CLI**: the showcase template's three submit buttons (forms demo, login, register) passed
+  `Type="submit"` to `BzButton`, whose `Type` parameter is the `ButtonType` enum, so a fresh
+  showcase did not compile. They pass `ButtonType.Submit` now (#27).
 - **Dialog, Sheet, Drawer, AlertDialog**: the first open no longer stutters. The surface rendered
   at its declaration site, started its entry animation there, and moved to `<body>` one interop
   roundtrip later, which restarts CSS animations - so the entry played twice, visibly on a cold

--- a/src/Blaizio.Cli/Assets/templates/showcase/Pages__FormsDemo~razor.tmpl
+++ b/src/Blaizio.Cli/Assets/templates/showcase/Pages__FormsDemo~razor.tmpl
@@ -132,7 +132,7 @@
         </BzField>
 
         <BzField>
-            <BzButton Type="submit">Save profile</BzButton>
+            <BzButton Type="ButtonType.Submit">Save profile</BzButton>
         </BzField>
     </BzFieldGroup>
 </EditForm>

--- a/src/Blaizio.Cli/Assets/templates/showcase/Pages__Login~razor.tmpl
+++ b/src/Blaizio.Cli/Assets/templates/showcase/Pages__Login~razor.tmpl
@@ -30,7 +30,7 @@
                         <BzFieldLabel Class="!w-auto" For="login-remember">Remember me</BzFieldLabel>
                     </BzField>
                     <BzField>
-                        <BzButton Type="submit" Class="w-full">Sign in</BzButton>
+                        <BzButton Type="ButtonType.Submit" Class="w-full">Sign in</BzButton>
                     </BzField>
                 </BzFieldGroup>
             </EditForm>

--- a/src/Blaizio.Cli/Assets/templates/showcase/Pages__Register~razor.tmpl
+++ b/src/Blaizio.Cli/Assets/templates/showcase/Pages__Register~razor.tmpl
@@ -36,7 +36,7 @@
                         <ValidationMessage For="@(() => _model.ConfirmPassword)" class="text-destructive text-sm" />
                     </BzField>
                     <BzField>
-                        <BzButton Type="submit" Class="w-full">Create account</BzButton>
+                        <BzButton Type="ButtonType.Submit" Class="w-full">Create account</BzButton>
                     </BzField>
                 </BzFieldGroup>
             </EditForm>


### PR DESCRIPTION
Fixes #27.

The showcase template's three submit buttons (forms demo, login, register) wrote `Type="submit"` on `BzButton`, whose `Type` parameter is the `ButtonType` enum, so a freshly scaffolded showcase did not compile. They pass `ButtonType.Submit` now.

Verified: rebuilt the CLI, ran `blaizio new showcase` against the local registry, `dotnet build` of the scaffold succeeds with no Razor errors. CHANGELOG under Unreleased.