### PR TITLE
fix(cli): dry-run gives each file the verdict the real run would

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ lockstep under one version.
 
 ## Unreleased
 
+### Fixed
+- **CLI**: `--dry-run` reports each file with the outcome the real run would give it. A file
+  kept for your edits (or left alone by a non-overwriting `add`) previews as skipped and a file
+  already at upstream as unchanged; only a file that would actually be written counts as
+  planned. The "would re-pull N file(s) changed" count previously included the kept and
+  unchanged files, so a preview overstated what `update -y` then did.
+
 ## 0.3.2 - 2026-09-10
 
 Dialog first-open stutter fixed at the source, `update` decides keep-or-take per file, the

--- a/src/Blaizio.Cli.Core/Writing/ComponentWriter.cs
+++ b/src/Blaizio.Cli.Core/Writing/ComponentWriter.cs
@@ -53,12 +53,11 @@ public sealed class ComponentWriter(
             var absolute = ResolveReported(projectDir, outputDir, reported);
             var exists = File.Exists(absolute);
 
-            if (dryRun)
-            {
-                results.Add(new WrittenFile(reported, WriteAction.Planned));
-                continue;
-            }
-
+            // The skip and unchanged verdicts come BEFORE the dry-run exit, so a preview reports
+            // the same per-file outcome the real run would: a file kept for your edits (or left
+            // alone by a non-overwriting add) is Skipped, one already at upstream is Unchanged,
+            // and only a file that would actually be written counts as Planned. A preview that
+            // called every file Planned overstated "N file(s) changed" by exactly those.
             var allowed = overwrite && keepLocal?.Contains(reported) != true;
             if (exists && !allowed)
             {
@@ -74,6 +73,12 @@ public sealed class ComponentWriter(
             if (exists && ContentHash.Matches(await ContentHash.OfFileAsync(absolute, ct), hash))
             {
                 results.Add(new WrittenFile(reported, WriteAction.Unchanged) { Hash = hash });
+                continue;
+            }
+
+            if (dryRun)
+            {
+                results.Add(new WrittenFile(reported, WriteAction.Planned));
                 continue;
             }
 

--- a/tests/Blaizio.Cli.Core.Tests/LocalEditsTests.cs
+++ b/tests/Blaizio.Cli.Core.Tests/LocalEditsTests.cs
@@ -207,6 +207,59 @@ public class LocalEditsTests
     }
 
     [Fact]
+    public async Task A_dry_run_previews_the_kept_file_as_skipped_and_the_current_one_as_unchanged()
+    {
+        // The preview must give each file the outcome the real run gives it, or "would re-pull
+        // N file(s)" counts files -y then keeps. Two files: one edited (kept), one already at
+        // upstream (unchanged); neither may preview as Planned.
+        const string Second = "Components/Ui/Button/Group.razor";
+        const string SecondRecorded = "Button/Group.razor";
+        using var dir = new TempDir();
+        var registry = new FakeRegistryClient().Add(new RegistryItem
+        {
+            Name = "button",
+            Files =
+            [
+                new RegistryFile { Path = "Ui/Button/Button.razor", Content = "<div>v1</div>" },
+                new RegistryFile { Path = "Ui/Button/Group.razor", Content = "<nav>v1</nav>" },
+            ],
+        });
+        var (service, _) = Build(dir, registry);
+        await service.RunAsync(new AddRequest { Components = ["button"], NoNuget = true });
+        dir.Write(Destination, "<div>mine</div>");
+
+        registry.Add(new RegistryItem
+        {
+            Name = "button",
+            Files =
+            [
+                new RegistryFile { Path = "Ui/Button/Button.razor", Content = "<div>v2</div>" },
+                new RegistryFile { Path = "Ui/Button/Group.razor", Content = "<nav>v1</nav>" },
+            ],
+        });
+        var preview = await service.RunAsync(new AddRequest
+        {
+            Components = ["button"], NoNuget = true, Overwrite = true, DryRun = true,
+        });
+
+        Assert.Equal(WriteAction.Skipped, ActionOf(preview));
+        Assert.Equal(WriteAction.Unchanged, preview.Files.Single(f => f.Path == SecondRecorded).Action);
+        Assert.DoesNotContain(preview.Files, f => f.Action == WriteAction.Planned);
+        var decision = Assert.Single(preview.Decisions);
+        Assert.Equal((Recorded, true), (decision.Path, decision.Kept));
+        Assert.Equal("<div>mine</div>", dir.Read(Destination)); // nothing written
+
+        // --force previews the forced outcome: the edited file would be written.
+        var forced = await service.RunAsync(new AddRequest
+        {
+            Components = ["button"], NoNuget = true, Overwrite = true, DryRun = true, Force = true,
+        });
+        Assert.Equal(WriteAction.Planned, ActionOf(forced));
+        Assert.False(Assert.Single(forced.Decisions).Kept);
+        Assert.Equal("<div>mine</div>", dir.Read(Destination));
+    }
+
+    [Fact]
     public async Task One_item_can_keep_one_edited_file_and_take_upstream_for_another()
     {
         // The case that made the decision per file: a component with two edited files, one a


### PR DESCRIPTION
A preview called every file `Planned`, including files kept for local edits, files a non-overwriting `add` leaves alone, and files already at upstream, so "would re-pull N file(s) changed" overstated what `update -y` then did. Decisions were already right; the count disagreed with them.

The skip and unchanged verdicts now come before the dry-run exit in `ComponentWriter`; only a file that would actually be written previews as `Planned`. Core test covers the kept, unchanged and `--force` previews. Cli.Core 490/490, Cli 171/171. CHANGELOG under Unreleased.