### PR TITLE
fix(build): revisioned packs get their own bin/obj so a plain pack never inherits them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ lockstep under one version.
 ## Unreleased
 
 ### Fixed
+- **Build**: a revisioned pack (the docs' local feed) now builds under its own `bin/rev` and
+  `obj/rev`. It used to share `obj/Release` with the plain pack, so a docs-server build between
+  two release packs left a four-part `Blaizio.Icons.dll` there and the next `Blaizio.Icons.Tabler`
+  pack compiled against it: a package calling itself 0.3.2 that referenced `Blaizio.Icons
+  0.3.2.80`, failing at runtime with "Could not load file or assembly". Only local packs were
+  affected; the 0.3.2 packages on nuget.org are clean.
 - **CLI**: `--dry-run` reports each file with the outcome the real run would give it. A file
   kept for your edits (or left alone by a non-overwriting `add`) previews as skipped and a file
   already at upstream as unchanged; only a file that would actually be written counts as

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -69,4 +69,19 @@
     <DefaultItemExcludes>$(DefaultItemExcludes);bin/**;obj/**</DefaultItemExcludes>
   </PropertyGroup>
 
+  <!--
+    A revisioned pack (the docs' local dogfood feed, BlaizioPackRevision set) builds its whole
+    ProjectReference graph with a four-part assembly version. Left on the plain obj/Release it
+    poisons the NEXT plain pack: incremental build sees Blaizio.Icons.dll up to date and hands
+    Blaizio.Icons.Tabler a 0.3.2.80 reference inside a package that calls itself 0.3.2 - the
+    consumer then fails at runtime with "Could not load file or assembly 'Blaizio.Icons,
+    Version=0.3.2.80'" (a docs-server build ran between two release packs, 2026-09-10). Revisioned
+    builds get their own bin/obj so the two never share an output; same rules as the e2e sandbox.
+  -->
+  <PropertyGroup Condition="'$(BlaizioPackRevision)' != '' and '$(BlaizioIsolatedOutput)' == ''">
+    <BaseOutputPath>bin/rev/</BaseOutputPath>
+    <BaseIntermediateOutputPath>obj/rev/</BaseIntermediateOutputPath>
+    <DefaultItemExcludes>$(DefaultItemExcludes);bin/**;obj/**</DefaultItemExcludes>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
A revisioned pack (docs local feed, `BlaizioPackRevision` set) shared `obj/Release` with the plain pack. A docs-server build between two release packs left `Blaizio.Icons.dll` stamped 0.3.2.80 there, and the next plain `Blaizio.Icons.Tabler` pack compiled against it: a package calling itself 0.3.2 referencing `Blaizio.Icons 0.3.2.80`. A consumer that restored that local pack failed at runtime with "Could not load file or assembly 'Blaizio.Icons, Version=0.3.2.80'". The nuget.org 0.3.2 packages were built clean in CI (verified by downloading all ten and reading their references).

Revisioned builds now use `bin/rev` and `obj/rev` with the old bin/obj excluded from default item globs, mirroring the e2e sandbox block. Verified locally: revisioned Tabler pack references Icons 0.3.2.999 under obj/rev, plain pack right after references 0.3.2.0. CHANGELOG under Unreleased.